### PR TITLE
Return jobid from put function

### DIFF
--- a/disque/connection.go
+++ b/disque/connection.go
@@ -55,12 +55,7 @@ func (d *Disque) Push(queueName string, job string, timeout time.Duration) (jobI
 		Add(queueName).
 		Add(job).
 		Add(int64(timeout.Seconds() * 1000))
-	r, err := d.call("ADDJOB", args)
-
-	switch r := r.(type) {
-	case string:
-		jobId = r
-	}
+	jobId, err = redis.String(d.call("ADDJOB", args))
 	return
 }
 
@@ -80,20 +75,15 @@ func (d *Disque) Push(queueName string, job string, timeout time.Duration) (jobI
 //     options["ASYNC"] = true
 //     d.PushWithOptions("queue_name", "job", 1*time.Second, options)
 func (d *Disque) PushWithOptions(queueName string, job string, timeout time.Duration, options map[string]string) (jobId string, err error) {
-	var r interface{}
 	if len(options) == 0 {
-		r, err = d.Push(queueName, job, timeout)
+		jobId, err = d.Push(queueName, job, timeout)
 	} else {
 		args := redis.Args{}.
 			Add(queueName).
 			Add(job).
 			Add(int64(timeout.Seconds() * 1000)).
 			AddFlat(optionsToArguments(options))
-		r, err = d.call("ADDJOB", args)
-	}
-	switch r := r.(type) {
-	case string:
-		jobId = r
+		jobId, err = redis.String(d.call("ADDJOB", args))
 	}
 	return
 }

--- a/disque/connection_test.go
+++ b/disque/connection_test.go
@@ -159,7 +159,7 @@ func (s *DisqueSuite) TestPushWithEmptyOptions() {
 	d.Initialize()
 	options := make(map[string]string)
 
-	err := d.PushWithOptions("queue1", "asdf", 1*time.Second, options)
+	_, err := d.PushWithOptions("queue1", "asdf", 1*time.Second, options)
 
 	assert.Nil(s.T(), err)
 }
@@ -172,7 +172,7 @@ func (s *DisqueSuite) TestPushWithOptions() {
 	options["TTL"] = "60"
 	options["ASYNC"] = "true"
 
-	err := d.PushWithOptions("queue1", "asdf", 1*time.Second, options)
+	_, err := d.PushWithOptions("queue1", "asdf", 1*time.Second, options)
 
 	assert.Nil(s.T(), err)
 }
@@ -186,7 +186,7 @@ func (s *DisqueSuite) TestPushWithOptionsOnClosedConnection() {
 	options["TTL"] = "60"
 	options["ASYNC"] = "true"
 
-	err := d.PushWithOptions("queue1", "asdf", 1*time.Second, options)
+	_, err := d.PushWithOptions("queue1", "asdf", 1*time.Second, options)
 
 	assert.Nil(s.T(), err)
 }
@@ -196,7 +196,7 @@ func (s *DisqueSuite) TestPush() {
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
 
-	err := d.Push("queue1", "asdf", 1*time.Second)
+	_, err := d.Push("queue1", "asdf", 1*time.Second)
 
 	assert.Nil(s.T(), err)
 }
@@ -207,7 +207,7 @@ func (s *DisqueSuite) TestPushToClosedConnection() {
 	d.Initialize()
 	d.Close()
 
-	err := d.Push("queue1", "asdf", 1*time.Second)
+	_, err := d.Push("queue1", "asdf", 1*time.Second)
 
 	assert.Nil(s.T(), err)
 }
@@ -219,7 +219,7 @@ func (s *DisqueSuite) TestPushToUnreachableNode() {
 	d.Close()
 	d.servers = []string{"127.0.0.1:7722"}
 
-	err := d.Push("queue1", "asdf", 1*time.Second)
+	_, err := d.Push("queue1", "asdf", 1*time.Second)
 
 	assert.NotNil(s.T(), err)
 }
@@ -228,7 +228,7 @@ func (s *DisqueSuite) TestQueueLength() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue3", "asdf", 1*time.Second)
+	_, err := d.Push("queue3", "asdf", 1*time.Second)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 0, d.stats[d.prefix])
 
@@ -246,7 +246,7 @@ func (s *DisqueSuite) TestQueueLengthOnClosedConnection() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue3", "asdf", 1*time.Second)
+	_, err := d.Push("queue3", "asdf", 1*time.Second)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 0, d.stats[d.prefix])
 	d.Close()
@@ -265,7 +265,7 @@ func (s *DisqueSuite) TestFetch() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue4", "asdf", 1*time.Second)
+	_, err := d.Push("queue4", "asdf", 1*time.Second)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 0, d.stats[d.prefix])
 
@@ -282,7 +282,7 @@ func (s *DisqueSuite) TestFetchWithNoJobs() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue4", "asdf", 1*time.Second)
+	_, err := d.Push("queue4", "asdf", 1*time.Second)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 0, d.stats[d.prefix])
 
@@ -296,9 +296,9 @@ func (s *DisqueSuite) TestFetchWithMultipleJobs() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue5", "msg1", 1*time.Second)
-	err = d.Push("queue5", "msg2", 1*time.Second)
-	err = d.Push("queue5", "msg3", 1*time.Second)
+	_, err := d.Push("queue5", "msg1", 1*time.Second)
+	_, err = d.Push("queue5", "msg2", 1*time.Second)
+	_, err = d.Push("queue5", "msg3", 1*time.Second)
 
 	jobs, err := d.FetchMultiple("queue5", 2, 1*time.Second)
 	assert.Nil(s.T(), err)
@@ -313,7 +313,7 @@ func (s *DisqueSuite) TestFetchMultipleWithNoJobs() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue4", "asdf", 1*time.Second)
+	_, err := d.Push("queue4", "asdf", 1*time.Second)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), 0, d.stats[d.prefix])
 
@@ -328,7 +328,7 @@ func (s *DisqueSuite) TestAck() {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)
 	d.Initialize()
-	err := d.Push("queue2", "asdf", 1*time.Second)
+	_, err := d.Push("queue2", "asdf", 1*time.Second)
 	assert.Nil(s.T(), err)
 
 	job, err := d.Fetch("queue2", 1*time.Second)


### PR DESCRIPTION
Merge in commit from @cedriclam to return the JobID from an ADDJOB call.  Make some minor improvements to use the Redigo type function rather than performing type inspection on our own.