### PR TITLE
add Del(JobId string) method to Disque

### DIFF
--- a/disque/connection.go
+++ b/disque/connection.go
@@ -110,6 +110,12 @@ func (d *Disque) Ack(jobId string) (err error) {
 	return
 }
 
+// Del delete Job onto Disque cluster thanks the JobId
+func (d *Disque) Del(jobID string) (err error) {
+	_, err = d.call("DELJOB", redis.Args{}.Add(jobID))
+	return
+}
+
 // Retrieve details for an existing job
 func (d *Disque) GetJobDetails(jobId string) (jobDetails *JobDetails, err error) {
 	var jobDetailsMap []interface{}

--- a/disque/connection_test.go
+++ b/disque/connection_test.go
@@ -412,6 +412,27 @@ func (s *DisqueSuite) TestAckWithMalformedJobId() {
 	assert.NotNil(s.T(), err)
 }
 
+func (s *DisqueSuite) TestDeleteJob() {
+	hosts := []string{"127.0.0.1:7711"}
+	d := NewDisque(hosts, 1000)
+	d.Initialize()
+
+	jobId, err := d.Push("queue3", "todelete", time.Second)
+	assert.Nil(s.T(), err)
+
+	err = d.Del(jobId)
+	assert.Nil(s.T(), err)
+}
+
+func (s *DisqueSuite) TestDeleteJobWithUnknownJobId() {
+	hosts := []string{"127.0.0.1:7711"}
+	d := NewDisque(hosts, 1000)
+	d.Initialize()
+
+	err := d.Del("badId")
+	assert.NotNil(s.T(), err)
+}
+
 func BenchmarkPush(b *testing.B) {
 	hosts := []string{"127.0.0.1:7711"}
 	d := NewDisque(hosts, 1000)


### PR DESCRIPTION
Aim of this method is to be able to delete a Job in Disque thanks to his ID.