### PR TITLE
fix Pool.Put(nil)

### DIFF
--- a/disque/connection_pool.go
+++ b/disque/connection_pool.go
@@ -55,9 +55,19 @@ func (p *Pool) Get(ctx context.Context) (conn *Disque, err error) {
 // Put will return a resource to the pool. For every successful Get,
 // a corresponding Put is required. If you no longer need a resource,
 // you will need to call Put(nil) instead of returning the closed resource.
-// The will eventually cause a new resource to be created in its place.
+// This will eventually cause a new resource to be created in its place.
 func (p *Pool) Put(conn *Disque) {
-	p.pool.Put(conn)
+	if conn == nil {
+		// Converting a concrete value (*Disque) into an interface value
+		// (pools.Resource) produces an interface value that is != nil, even if
+		// the concrete value was nil.
+		//
+		// Instead, we create a new nil value of type pools.Resource which is
+		// == nil, because it doesn't have a concrete type.
+		p.pool.Put(nil)
+	} else {
+		p.pool.Put(conn)
+	}
 }
 
 // Close empties the pool calling Close on all its resources.

--- a/disque/connection_pool_test.go
+++ b/disque/connection_pool_test.go
@@ -38,3 +38,21 @@ func (s *DisquePoolSuite) TestWithPoolOfOne() {
 	c, err = p.Get(context.Background())
 	s.NotNil(err)
 }
+
+func (s *DisquePoolSuite) TestPutNil() {
+	hosts := []string{"127.0.0.1:7711"}
+	p := NewPool(hosts, 1000, 1, 1, time.Hour)
+
+	c, err := p.Get(context.Background())
+	s.Nil(err)
+	s.NotNil(c)
+
+	// Assume node or network failure here. c is now unusable and should not
+	// be returned to the pool.
+	p.Put(nil)
+
+	// Now we expect to Get a new connection
+	c, err = p.Get(context.Background())
+	s.Nil(err)
+	s.NotNil(c)
+}


### PR DESCRIPTION
Interfaces are compound types consisting of a runtime type and a value.
Only if both components are nil is the interface value itself nil. So as
soon as a concrete value is converted into an interface value that
interface value is != nil.

https://play.golang.org/p/UTcCNFawpm
```go
    package main

    import (
            "fmt"
            "net/url"
    )

    func main() {
            var c *url.URL         // c is a concrete value
            var i fmt.Stringer = c // i is an interface value

            fmt.Println(c, c == nil)
            fmt.Println(i, i == nil)
    }

    # Output:
    # <nil> true
    # <nil> false
```

This happened in Pool.Put, where a *Disque was converted into a
"github.com/youtube/vitess/go/pools".Resource. Vitesses ResourcePool
then did not recognize this as a nil value and would eventually return
it from a Get call. Pool.Get converts the nil back into a
value of type *Disque just waiting to produce a nil pointer panic.